### PR TITLE
Add clang-tools-extra to fedora-36

### DIFF
--- a/Containerfile.fedora-36
+++ b/Containerfile.fedora-36
@@ -3,6 +3,7 @@ FROM docker.io/fedora:36
 RUN dnf upgrade -y
 RUN dnf install -y --setopt=install_weak_deps=False \
     clang \
+    clang-tools-extra \
     cmake \
     doxygen \
     gcc \


### PR DESCRIPTION
Signed-off-by: Tristan Partin <tpartin@micron.com>