### PR TITLE
Remove xxhash from Fedora 36

### DIFF
--- a/Containerfile.fedora-36
+++ b/Containerfile.fedora-36
@@ -30,7 +30,6 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     python3-devel \
     python3-pip \
     userspace-rcu-devel \
-    which \
-    xxhash-devel
+    which
 RUN python3 -m pip install meson==0.62.2
 RUN ulimit -c unlimited


### PR DESCRIPTION
HSE doesn't even support compiling against it, so remove.

Signed-off-by: Tristan Partin <tpartin@micron.com>