### PR TITLE
Add tcmalloc

### DIFF
--- a/Containerfile.almalinux-8
+++ b/Containerfile.almalinux-8
@@ -9,6 +9,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     gcc \
     gcc-c++ \
     git \
+    gperftools-devel \
     java-1.8.0-openjdk-devel \
     libbsd-devel \
     libbson-devel \

--- a/Containerfile.almalinux-9
+++ b/Containerfile.almalinux-9
@@ -9,6 +9,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     gcc \
     gcc-c++ \
     git \
+    gperftools-devel \
     java-1.8.0-openjdk-devel \
     libbsd-devel \
     libbson-devel \

--- a/Containerfile.cross
+++ b/Containerfile.cross
@@ -21,6 +21,7 @@ RUN apt-get -y install --no-install-recommends \
     g++-${crossArch}-linux-gnu \
     git \
     libncurses-dev:${crossArch} \
+    libtcmalloc-minimal4:${crossArch} \
     libpython3-dev:${crossArch} \
     libtool \
     make \

--- a/Containerfile.fedora-36
+++ b/Containerfile.fedora-36
@@ -10,6 +10,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     gcc \
     gcc-c++ \
     git \
+    gperftools-devel \
     HdrHistogram_c-devel \
     java-latest-openjdk-devel \
     libasan \

--- a/Containerfile.ubuntu-18.04
+++ b/Containerfile.ubuntu-18.04
@@ -21,6 +21,7 @@ RUN apt-get -y install --no-install-recommends \
     libmongoc-dev \
     libncurses-dev \
     libpmem-dev \
+    libtcmalloc-minimal4 \
     liburcu-dev \
     libyaml-dev \
     maven \

--- a/Containerfile.ubuntu-20.04
+++ b/Containerfile.ubuntu-20.04
@@ -21,6 +21,7 @@ RUN apt-get -y install --no-install-recommends \
     libmongoc-dev \
     libncurses-dev \
     libpmem-dev \
+    libtcmalloc-minimal4 \
     liburcu-dev \
     libyaml-dev \
     maven \

--- a/Containerfile.ubuntu-22.04
+++ b/Containerfile.ubuntu-22.04
@@ -19,6 +19,7 @@ RUN apt-get -y install --no-install-recommends \
     libmongoc-dev \
     libncurses-dev \
     libpmem-dev \
+    libtcmalloc-minimal4 \
     liburcu-dev \
     libyaml-dev \
     maven \


### PR DESCRIPTION
This was born out of a discussion between us discussing the removal of
alloc_aligned() and free_aligned() from the HSE codebase. In that
discussion, we looked a bit at alternative allocators. tcmalloc proved
to be the most performant allocator based on Greg's little bit of
testing.

tcmalloc will (hopefully) become an optional dependency of HSE, so we
can drop our custom aligned allcator API.

Signed-off-by: Tristan Partin <tpartin@micron.com>