### PR TITLE
Use meson setup

### DIFF
--- a/.github/workflows/images.ignore.yaml
+++ b/.github/workflows/images.ignore.yaml
@@ -21,7 +21,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  images:
+  image:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ if [ -n "${CROSS_ARCH}" ]; then
 fi
 
 # shellcheck disable=SC2086
-meson builddir hse --fatal-meson-warnings --werror ${cross_args} \
+meson setup builddir hse --fatal-meson-warnings --werror ${cross_args} \
     -Dbindings=all -Dtools=enabled
 ninja -C builddir
 


### PR DESCRIPTION
Leaving out the setup command is deprecated in Meson master.

Signed-off-by: Tristan Partin <tpartin@micron.com>