### PR TITLE
Add compiler-rt for RHEL-related images

### DIFF
--- a/Containerfile.almalinux-8
+++ b/Containerfile.almalinux-8
@@ -8,6 +8,7 @@ RUN dnf upgrade -y
 RUN dnf install -y --setopt=install_weak_deps=False \
     clang \
     cmake \
+    compiler-rt \
     gcc \
     gcc-c++ \
     git \

--- a/Containerfile.almalinux-9
+++ b/Containerfile.almalinux-9
@@ -8,6 +8,7 @@ RUN dnf upgrade -y
 RUN dnf install -y --setopt=install_weak_deps=False \
     clang \
     cmake \
+    compiler-rt \
     gcc \
     gcc-c++ \
     git \

--- a/Containerfile.fedora-36
+++ b/Containerfile.fedora-36
@@ -8,6 +8,7 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     clang \
     clang-tools-extra \
     cmake \
+    compiler-rt \
     doxygen \
     gcc \
     gcc-c++ \


### PR DESCRIPTION
compiler-rt is needed for sanitizer usage with clang.

Signed-off-by: Tristan Partin <tpartin@micron.com>