### PR TITLE
Move Fedora image to 37

### DIFF
--- a/.github/workflows/images.ignore.yaml
+++ b/.github/workflows/images.ignore.yaml
@@ -30,7 +30,7 @@ jobs:
           - almalinux-8
           - almalinux-9
           - cross-s390x
-          - fedora-36
+          - fedora-37
           - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -43,7 +43,7 @@ jobs:
           - almalinux-8
           - almalinux-9
           - cross-s390x
-          - fedora-36
+          - fedora-37
           - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04

--- a/Containerfile.fedora-37
+++ b/Containerfile.fedora-37
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:36
+FROM docker.io/fedora:37
 
 ARG mesonVersion
 


### PR DESCRIPTION
37 released today (11/15/2022).

Signed-off-by: Tristan Partin <tpartin@micron.com>