### PR TITLE
Add support for using a specified Meson version in workflow dispatches

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -21,6 +21,9 @@ on:
         description: Branch to build (master, vX.Y)
         required: true
         default: master
+      meson-version:
+        description: Meson version to use
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -59,6 +62,11 @@ jobs:
           else
             echo "branch=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Update Meson version
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "MESON_VERSION=${{ github.event.inputs.meson-version }}" >> "$GITHUB_ENV"
 
       - name: Export image
         id: export-image


### PR DESCRIPTION
This will aid in testing future Meson pre-releases.

Signed-off-by: Tristan Partin <tpartin@micron.com>